### PR TITLE
Feature/refactor create keywords and results service

### DIFF
--- a/app/jobs/create_results_job.rb
+++ b/app/jobs/create_results_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateResultsJob
+  include Sidekiq::Job
+  sidekiq_options queue: 'default'
+
+  URL = 'https://www.google.com/search'
+
+  def perform(keywords, url: nil)
+    url ||= URL
+    crawler = SearchCrawler.new(keywords, url: url)
+    crawler.results.each do |result|
+      CreateResultService.call(result)
+    end
+  end
+end

--- a/app/models/search_crawler.rb
+++ b/app/models/search_crawler.rb
@@ -2,7 +2,7 @@
 
 class SearchCrawler
   class YouAreABot < StandardError; end
-  USER_AGENT = [
+  USER_AGENTS = [
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.79 Safari/537.36',
     'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36',
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36',
@@ -31,7 +31,7 @@ class SearchCrawler
 
   def user_agent_headers
     {
-      'USER_AGENT' => USER_AGENT.sample
+      'USER_AGENT' => USER_AGENTS.sample
     }
   end
 

--- a/app/models/search_crawler.rb
+++ b/app/models/search_crawler.rb
@@ -3,9 +3,11 @@
 class SearchCrawler
   class YouAreABot < StandardError; end
   USER_AGENTS = [
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.79 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) '\
+    'Chrome/104.0.5112.79 Safari/537.36',
     'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 '\
+    '(KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36',
     'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.53 Safari/537.36'
   ].freeze
   HEADERS = {
@@ -30,9 +32,7 @@ class SearchCrawler
   end
 
   def user_agent_headers
-    {
-      'USER_AGENT' => USER_AGENTS.sample
-    }
+    { 'USER_AGENT' => USER_AGENTS.sample }
   end
 
   def results

--- a/app/models/search_crawler.rb
+++ b/app/models/search_crawler.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+class SearchCrawler
+  class YouAreABot < StandardError; end
+  USER_AGENT = [
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.79 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.53 Safari/537.36'
+  ].freeze
+  HEADERS = {
+    'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
+    'Accept-Language' => 'en-US,en;q=0.9',
+    'Content-Type' => 'text/plain',
+    'Referer' => 'https://www.google.com'
+  }.freeze
+  attr_accessor :keywords, :url
+
+  def initialize(keywords_ids, url)
+    @keywords = Keyword.where(id: keywords_ids)
+    @url = url
+    @results = []
+    @browser = set_browser
+  end
+
+  def set_browser
+    Ferrum::Browser.new(headless: true,
+                        browser_options: { 'disable-blink-features': 'AutomationControlled' },
+                        timeout: 100)
+  end
+
+  def user_agent_headers
+    {
+      'USER_AGENT' => USER_AGENT.sample
+    }
+  end
+
+  def results
+    return if @keywords.empty?
+
+    init_search
+    crawl_results
+    @results
+  ensure
+    exit_browser
+  end
+
+  private
+
+  def crawl_results
+    @keywords.each_with_index do |keyword, index|
+      raise YouAreABot, 'Detected By Google' if check_captcha_exists?
+
+      submit_search(keyword.name) unless index.zero?
+      act_like_human
+      @results << result_params(keyword.id)
+    rescue YouAreABot
+      next
+    end
+  end
+
+  def act_like_human
+    @browser.mouse
+            .scroll_to(rand(0..500), rand(500..1000))
+            .scroll_to(rand(500..1000), rand(1000..2000))
+            .scroll_to(rand(500..1000), rand(2000..3500))
+  end
+
+  def submit_search(keyword)
+    clear_btn = @browser.at_xpath("//div[@aria-label='Clear']")
+    clear_btn.click
+    @browser.keyboard.type(keyword, :Enter)
+  rescue Ferrum::NodeNotFoundError
+    sleep 0.1
+    retry
+  end
+
+  def result_params(keyword_id)
+    {
+      keyword_id: keyword_id,
+      stats: stats,
+      total_urls: urls,
+      total_advertisers: total_advertisers,
+      html_file: @browser.body
+    }
+  rescue Ferrum::NodeNotFoundError
+    sleep 0.1
+    retry
+  end
+
+  def check_captcha_exists?
+    @browser.at_xpath("//form[@id='captcha-form']").present?
+  end
+
+  def stats
+    node = @browser.at_xpath("//div[@id='result-stats']")
+    raise Ferrum::NodeNotFoundError, 'node' unless node
+
+    node.text
+  end
+
+  def urls
+    @browser.css('a').pluck(:href).count
+  end
+
+  def total_advertisers
+    @browser.xpath("//div[@data-text-ad='1']").count
+  end
+
+  def init_search
+    @browser.headers.set(HEADERS)
+    @browser.headers.add(user_agent_headers)
+    @browser.go_to(encode_url)
+  end
+
+  def encode_url
+    URI.parse("#{@url}?q=#{@keywords[0].name}&hl=en").to_s
+  end
+
+  def exit_browser
+    @browser&.reset
+    @browser&.quit
+  end
+end

--- a/app/services/create_keywords_and_results_service.rb
+++ b/app/services/create_keywords_and_results_service.rb
@@ -1,116 +1,23 @@
 # frozen_string_literal: true
 
 class CreateKeywordsAndResultsService < ApplicationService
-  class YouAreABot < StandardError; end
-  HEDAERS = {
-    'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
-    'Accept-Language' => 'en-US,en;q=0.9',
-    'Content-Type' => 'text/plain',
-    'Referer' => 'https://www.google.com',
-    'USER_AGENT' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7 '\
-                    'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36'
-  }.freeze
-  URL = 'https://www.google.com/search'
-
-  def initialize(search_id, url: nil)
+  def initialize(search_id)
     @search = Search.find_by id: search_id
-    @keywords = @search.keywords_from_file
-    @browser = set_browser
-    @url = url || URL
+    @keywords = CsvService.call(@search)
     super
   end
 
   def call
     return if @keywords.empty?
 
-    init_search
-    create_keywords_and_results
-    act_like_human
-  ensure
-    exit_browser
+    create_keywords
   end
 
-  def create_keywords_and_results
-    @keywords.each_with_index do |key, index|
-      raise YouAreABot, 'Detected By Google' if check_captcha_exists?
-
-      keyword = CreateKeywordService.call(key, @search.id)
-      google_search(keyword.name) unless index.zero?
-      CreateResultService.call(result_params(keyword.id))
-    rescue YouAreABot
-      next
+  def create_keywords
+    @keywords.each_slice(10) do |keys|
+      saved_keywords = []
+      keys.each { |key| saved_keywords << CreateKeywordService.call(key, @search.id) }
+      CreateResultsJob.perform_async(saved_keywords.pluck(:id))
     end
-  end
-
-  def set_browser
-    Ferrum::Browser.new(headless: true,
-                        browser_options: { 'disable-blink-features': 'AutomationControlled' },
-                        timeout: 100)
-  end
-
-  def exit_browser
-    @browser&.reset
-    @browser&.quit
-  end
-
-  private
-
-  def encode_url
-    URI.parse("#{@url}?q=#{@keywords[0]}&hl=en").to_s
-  end
-
-  def init_search
-    @browser.headers.set(HEDAERS)
-    @browser.go_to(encode_url)
-  end
-
-  def act_like_human
-    sleep rand(5)
-    @browser.mouse
-            .scroll_to(rand(0..500), rand(500..1000))
-            .scroll_to(rand(500..1000), rand(1000..2000))
-            .scroll_to(rand(500..1000), rand(2000..3500))
-    sleep rand(5)
-  end
-
-  def google_search(keyword)
-    clear_btn = @browser.at_xpath("//div[@aria-label='Clear']")
-    clear_btn.click
-    @browser.keyboard.type(keyword, :Enter)
-  rescue Ferrum::NodeNotFoundError
-    sleep 0.1
-    retry
-  end
-
-  def result_params(keyword_id)
-    {
-      keyword_id: keyword_id,
-      stats: stats,
-      total_urls: urls,
-      total_advertisers: total_advertisers,
-      html_file: @browser.body
-    }
-  rescue Ferrum::NodeNotFoundError
-    sleep 0.1
-    retry
-  end
-
-  def check_captcha_exists?
-    @browser.at_xpath("//form[@id='captcha-form']").present?
-  end
-
-  def stats
-    node = @browser.at_xpath("//div[@id='result-stats']")
-    raise Ferrum::NodeNotFoundError, 'node' unless node
-
-    node.text
-  end
-
-  def urls
-    @browser.css('a').pluck(:href).count
-  end
-
-  def total_advertisers
-    @browser.xpath("//div[@data-text-ad='1']").count
   end
 end

--- a/app/services/csv_service.rb
+++ b/app/services/csv_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CsvService < ApplicationService
+  def initialize(search)
+    @search = search
+    super
+  end
+
+  def call
+    csv = @search.csv_file.download
+    csv.gsub(', ', ',').tr("\n", ',').split(',')
+  end
+end

--- a/public/test.html
+++ b/public/test.html
@@ -1,17 +1,21 @@
-<html lang="en">
-
+<!doctype html>
+<html>
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Test</title>
 </head>
-
 <body>
-  <div>
-    <div id="result-stats">About 1 result</div>
-    <div data-text-ad="1" data-hveid="CAsQAA"> <a href="#"> Test 1 </a> </div><a href="#"> Test 2 </a>
+  <input type="text" aria-label="Search">
+  <div aria-label="Clear" role="button">Clear</div>
+  <div id="result-stats">About 607,000,000 results<nobr>(0.59 seconds)&nbsp;</nobr></div>
+  <div data-text-ad="1" data-hveid="CAkQAA">
+    <a href='https://www.foo.com'>Foo</a>
   </div>
+  <div data-text-ad="1" data-hveid="CAkQAA">
+    <a href='https://www.bar.com'>bar </a>
+  </div>
+  <div data-text-ad="1" data-hveid="CAkQAA">
+    <a href='https://www.lorem.com'>lorem </a>
+  </div>
+  <a href='https://www.ipsum.com'> ipsum</a>
 </body>
-
 </html>

--- a/spec/fixtures/files/test.csv
+++ b/spec/fixtures/files/test.csv
@@ -1,3 +1,3 @@
-cheap shared hosting
-inexpensive web hosting
-cheap web hosting wordpress
+cheap shared hosting, johnny deep
+inexpensive web hosting, hello world
+cheap web hosting wordpress,trips

--- a/spec/fixtures/vcr/google.yml
+++ b/spec/fixtures/vcr/google.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:53077/json/version
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - 127.0.0.1:53077
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '443'
+      Content-Type:
+      - application/json; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "Browser": "HeadlessChrome/108.0.5359.124",
+           "Protocol-Version": "1.3",
+           "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/108.0.5359.124 Safari/537.36",
+           "V8-Version": "10.8.168.22",
+           "WebKit-Version": "537.36 (@603c1cb86aff29563721da2a6351c0d08865350d)",
+           "webSocketDebuggerUrl": "ws://127.0.0.1:53077/devtools/browser/91010309-78d3-4839-94f6-f7c4c35eea2d"
+        }
+  recorded_at: Mon, 09 Jan 2023 19:00:54 GMT
+recorded_with: VCR 6.1.0

--- a/spec/jobs/create_results_job_spec.rb
+++ b/spec/jobs/create_results_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe CreateResultsJob, type: :job do
+  subject(:job) { described_class.perform_async([]) }
+
+  it 'queues the job' do
+    expect { job }
+      .to change(described_class.jobs, :size).by(1)
+  end
+
+  it 'is in default queue' do
+    job
+    expect(described_class.jobs.first['queue']).to eq('default')
+  end
+
+  describe 'perform' do
+    let(:url) { URI.join('file:///', Rails.public_path.join('test.html').to_s) }
+
+    it 'executes perform' do
+      crawler = instance_double(SearchCrawler)
+      allow(SearchCrawler).to receive(:new).and_return(crawler)
+      allow(crawler).to receive(:results).and_return([])
+
+      described_class.new.perform([], url: url)
+    end
+  end
+end

--- a/spec/jobs/import_keywords_job_spec.rb
+++ b/spec/jobs/import_keywords_job_spec.rb
@@ -3,8 +3,10 @@
 require 'rails_helper'
 require 'sidekiq/testing'
 
-RSpec.describe CreateResultsJob, type: :job do
-  subject(:job) { described_class.perform_async([]) }
+RSpec.describe ImportKeywordsJob, type: :job do
+  subject(:job) { described_class.perform_async(search.id) }
+
+  let(:search) { Fabricate.create(:search) }
 
   it 'queues the job' do
     expect { job }
@@ -18,11 +20,8 @@ RSpec.describe CreateResultsJob, type: :job do
 
   describe 'perform' do
     it 'executes perform' do
-      crawler = instance_double(SearchCrawler)
-      allow(SearchCrawler).to receive(:new).and_return(crawler)
-      allow(crawler).to receive(:results).and_return([])
-
-      described_class.new.perform([])
+      allow(CreateKeywordsAndResultsService).to receive(:call).and_return(true)
+      described_class.new.perform(search.id)
     end
   end
 end

--- a/spec/models/search_crawler_spec.rb
+++ b/spec/models/search_crawler_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SearchCrawler do
+  let(:url) { URI.join('file:///', Rails.public_path.join('test.html').to_s) }
+
+  describe 'initialize' do
+    it { expect { described_class.new([], '') }.not_to raise_error }
+  end
+
+  describe 'set_browser' do
+    it 'set ferrum browser' do
+      allow(Ferrum::Browser).to receive(:new).and_return('foo')
+      expect(described_class.new([], '').set_browser).to eq('foo')
+    end
+  end
+
+  describe 'user_agent_headers' do
+    it 'return user_agent hash' do
+      expect(described_class.new([], '').user_agent_headers.keys).to eq(['USER_AGENT'])
+    end
+  end
+
+  describe '#results' do
+    let(:keyword) { Fabricate.create(:keyword, name: 'cheap ticket') }
+    let(:crawler) { described_class.new([keyword], url) }
+
+    it { expect { crawler.results }.not_to raise_error }
+    it { expect(crawler.results.class).to be(Array) }
+    it { expect(crawler.results[0][:keyword_id]).to eq(keyword.id) }
+
+    # rubocop:disable RSpec/StubbedMock, RSpec/MultipleExpectations, RSpec/AnyInstance
+    it 'ensure exist browser' do
+      expect_any_instance_of(Ferrum::Browser).to receive(:reset).and_return(true)
+      expect_any_instance_of(Ferrum::Browser).to receive(:quit).and_return(true)
+      crawler.results
+    end
+    # rubocop:enable RSpec/StubbedMock, RSpec/MultipleExpectations, RSpec/AnyInstance
+  end
+
+  describe 'with VCR' do
+    let(:url) { CreateResultsJob::URL }
+
+    # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+    it 'return results' do
+      VCR.use_cassette('google') do
+        crawler = described_class.new([Fabricate.create(:keyword)], url)
+        results = crawler.results
+        expect(results[0][:total_urls]).not_to be_nil
+        expect(results[0][:total_advertisers]).not_to be_nil
+        expect(results[0][:stats]).not_to be_nil
+        expect(results[0][:keyword_id]).not_to be_nil
+      end
+    end
+    # rubocop:enable RSpec/MultipleExpectations, RSpec/ExampleLength
+  end
+end

--- a/spec/models/search_crawler_spec.rb
+++ b/spec/models/search_crawler_spec.rb
@@ -45,8 +45,7 @@ RSpec.describe SearchCrawler do
     # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
     it 'return results' do
       VCR.use_cassette('google') do
-        crawler = described_class.new([Fabricate.create(:keyword)], url)
-        results = crawler.results
+        results = described_class.new([Fabricate.create(:keyword)], url).results
         expect(results[0][:total_urls]).not_to be_nil
         expect(results[0][:total_advertisers]).not_to be_nil
         expect(results[0][:stats]).not_to be_nil

--- a/spec/services/create_keywords_and_results_service_spec.rb
+++ b/spec/services/create_keywords_and_results_service_spec.rb
@@ -5,42 +5,21 @@ require 'rails_helper'
 RSpec.describe CreateKeywordsAndResultsService do
   include ActiveStorage::Blob::Analyzable
 
-  subject(:service) { described_class.new(search.id) }
+  subject(:service) { described_class.new(search.id).call }
 
   let(:search) { Fabricate.create :search }
-  let(:keyword) { Fabricate.create :keyword }
-  let(:url) { URI.join('file:///', Rails.public_path.join('test.html').to_s) }
-  let(:result) { Fabricate.create :result }
 
   describe 'call' do
     it 'return if keywords are empty' do
       allow(Search).to receive(:find_by).and_return(search)
-      allow(search).to receive(:keywords_from_file).and_return([])
-      expect(described_class.call(search.id)).to be_nil
+      allow(CsvService).to receive(:call).and_return([])
+      expect(service).to be_nil
     end
 
-    # rubocop:disable Layout/AnyInstance, RSpec/MultipleExpectations, RSpec/MessageSpies, Rspec/ExampleLength
-    it 'create keyword and result' do
-      allow_any_instance_of(described_class).to receive(:google_search).and_return(true)
-      allow_any_instance_of(described_class).to receive(:act_like_human).and_return(true)
-      expect(CreateKeywordService)
-        .to receive(:call)
-        .and_return(keyword)
-        .exactly(search.keywords_from_file.count).times
-      expect(CreateResultService)
-        .to receive(:call)
-        .and_return(true)
-        .exactly(search.keywords_from_file.count).times
-      described_class.call(search.id, url: url)
+    it 'create keywords' do
+      allow(CreateResultsJob).to receive(:perform_async).and_return(true)
+      service
+      expect(Keyword.count).to eq(CsvService.call(search).count)
     end
-    # rubocop:enable Layout/AnyInstance, RSpec/MultipleExpectations, RSpec/MessageSpies,  Rspec/ExampleLength
-  end
-
-  describe 'set_browser' do
-    it { expect { service.set_browser }.not_to raise_error }
-  end
-
-  describe 'exit_browser' do
-    it { expect { service.exit_browser }.not_to raise_error }
   end
 end

--- a/spec/services/csv_service_spec.rb
+++ b/spec/services/csv_service_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CsvService do
+  include ActiveStorage::Blob::Analyzable
+  subject(:csv_service) { described_class.call(Fabricate.create(:search)) }
+
+  describe 'call' do
+    it { expect { csv_service }.not_to raise_error }
+
+    it { expect(csv_service.count).to eq(6) }
+
+    it { expect(csv_service.class).to eq(Array) }
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -4,6 +4,7 @@ require 'vcr'
 
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/vcr'
+  c.allow_http_connections_when_no_cassette = true
   c.hook_into :webmock
   c.ignore_request do |request|
     URI(request.uri).port == 9200

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -4,9 +4,7 @@ require 'vcr'
 
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/vcr'
-  c.allow_http_connections_when_no_cassette = false
   c.hook_into :webmock
-  c.ignore_localhost = true
   c.ignore_request do |request|
     URI(request.uri).port == 9200
   end


### PR DESCRIPTION
#24 #26 #20

I separate create_keywords_and_results service into two parts

- CsvService is now returning array from the csv file.
- Keywords creating in batch first and calling CreateResultsJob for creating result as a background job.
My thinking process is not to stress out sidekiq memory usage per thread. 
Therefore, I each_slice 10 from keywords, find_or_create keywords per user then calling CreateResultsJob.

In CreateResultsJob, 
I separate browser logic as  a SearchCrawler PORO which return results and loop save them as a result.
Also SearchCrawler is  using mixed User Agents to reduce detection as a bot.


