### PR TITLE
make sure the migration update all associations

### DIFF
--- a/db/migrate/20230109133954_convert_keyword_user_to_keywords.rb
+++ b/db/migrate/20230109133954_convert_keyword_user_to_keywords.rb
@@ -1,27 +1,55 @@
 class ConvertKeywordUserToKeywords < ActiveRecord::Migration[7.0]
   def up
-    add_reference :keywords, :user, foreign_key: true
+    #Remove name index from keywords table
     remove_index :keywords, :name
+    #Add user_id in keywords table
+    add_reference :keywords, :user, foreign_key: true
+    #Add user_ids from keywords_user table to keywords table
     execute "INSERT INTO keywords(name, user_id, created_at, updated_at) " \
       "select keywords.name, keyword_users.user_id, NOW(), NOW() " \
       "From keyword_users " \
       "JOIN keywords ON keyword_users.keyword_id = keywords.id"
+    #Update SearchKeyword table due to new keywords are inserted
+    Search.all.each do |search|
+      search.keywords.each do |keyword|
+        s_keyword = SearchKeyword.find_by(search_id: search.id, keyword_id: keyword.id)
+        act_key = Keyword.find_by(name: keyword.name, user_id: search.user_id)
+        keyword.result.update(keyword_id: act_key.id) if keyword.result
+        s_keyword.update(keyword_id: act_key.id) if act_key
+      end
+    end
+    # drop table keyword_users
     drop_table :keyword_users
+    # remove old keywords which has user id nil
     Keyword.where(user_id: nil).destroy_all
   end
 
   def down
+    #You need to create KeywordUser model, with belongs_to :user and belongs_to :keyword
+    #create keyword_users table
     create_table :keyword_users do |t|
-      t.belongs_to :user
-      t.belongs_to :keyword
+      t.belongs_to :user, foreign_key: true
+      t.belongs_to :keyword, foreign_key: true
       t.timestamps
     end
+    #insert values from keywords user_id column to keyword_users table
     execute "INSERT INTO keyword_users(user_id, keyword_id, created_at, updated_at) " \
       "select user_id, id, created_at, updated_at " \
       "From keywords"
-    add_foreign_key :keyword_users, :users
-    add_foreign_key :keyword_users, :keywords
-    add_index :keywords, :name
+    #remove user_id from keywords table
     remove_reference :keywords, :user
+    #remove dup keywords, since user_id is remove, keywords can be duplicated,
+    dup_records = Keyword.where.not(id: Keyword.select("MIN(id) as id").group(:name))
+    dup_records.each do |record|
+      k_user = KeywordUser.find_by(keyword_id: record.id)
+      id = Keyword.select("MIN(id) as id").where(name: record.name).ids.first
+      k_user.update(keyword_id: id)
+      result = record.result
+      result.update(keyword_id: id) if record.result
+    end
+    #destroy all dup records
+    dup_records.destroy_all
+    #can safely added name as index in keywords table
+    add_index :keywords, :name
   end
 end


### PR DESCRIPTION
#19 
Error : If two users search same keyword, they are having same result even geo difference.
There are two ways which is possible. 

1. keyword has many results and results belongs to both keyword and users
2. users has many keywords, keywords belongs to user.

I think No. 1 is more ideal but I wanna try to replace has_many :through with has_many.
Therefore I  approached No.2 . 

Goal : Remove has_many  :through for keyword_users, and replace with has_many  for users.

Since keywords and users are associated with has_many :through. 
And keywords and searches are also associated with has_many :through

1.Add user_id in keywords table
2.Insert keyword related info from keywords_user table to keywords table
3.Since search_keyword records are pointing to old keywords with user_id nil, I have to update them as well.
4.Result has to update as well since the old keyword is no longer valid.
5.Drop_table keywords_user
6. Remove keywords which doesn't has user_id



